### PR TITLE
removes unused address checks

### DIFF
--- a/contracts/ShapeShiftDAORouter.sol
+++ b/contracts/ShapeShiftDAORouter.sol
@@ -341,13 +341,11 @@ contract ShapeShiftDAORouter is Ownable {
                 vault.balanceOf(withdrawer),
                 vault.maxAvailableShares()
             );
-            if (withdrawer != address(this)) {
-                // Restrict by the allowance that `withdrawer` has given to this contract
-                availableShares = Math.min(
-                    availableShares,
-                    vault.allowance(withdrawer, address(this))
-                );
-            }
+            // Restrict by the allowance that `withdrawer` has given to this contract
+            availableShares = Math.min(
+                availableShares,
+                vault.allowance(withdrawer, address(this))
+            );
             if (availableShares == 0) continue;
 
             uint256 maxShares;
@@ -491,10 +489,7 @@ contract ShapeShiftDAORouter is Ownable {
         require(afterWithdrawBal > afterDepositBal, "deposit failed");
         migrated = afterWithdrawBal - afterDepositBal;
 
-        if (
-            migrator != address(this) &&
-            afterWithdrawBal - beforeWithdrawBal > migrated
-        ) {
+        if (afterWithdrawBal - beforeWithdrawBal > migrated) {
             SafeERC20.safeTransfer(
                 token,
                 migrator,

--- a/contracts/ShapeShiftDAORouter.sol
+++ b/contracts/ShapeShiftDAORouter.sol
@@ -362,27 +362,24 @@ contract ShapeShiftDAORouter is Ownable {
                 maxShares = availableShares;
             }
 
-            if (withdrawer != address(this)) {
-                uint256 beforeBal = vault.balanceOf(address(this));
+            uint256 beforeBal = vault.balanceOf(address(this));
 
-                SafeERC20.safeTransferFrom(
+            SafeERC20.safeTransferFrom(
+                vault,
+                withdrawer,
+                address(this),
+                maxShares
+            );
+
+            withdrawn += vault.withdraw(maxShares, recipient);
+
+            uint256 afterWithdrawBal = vault.balanceOf(address(this));
+            if (afterWithdrawBal > beforeBal) {
+                SafeERC20.safeTransfer(
                     vault,
                     withdrawer,
-                    address(this),
-                    maxShares
+                    afterWithdrawBal - beforeBal
                 );
-
-                withdrawn += vault.withdraw(maxShares, recipient);
-
-                uint256 afterWithdrawBal = vault.balanceOf(address(this));
-                if (afterWithdrawBal > beforeBal)
-                    SafeERC20.safeTransfer(
-                        vault,
-                        withdrawer,
-                        afterWithdrawBal - beforeBal
-                    );
-            } else {
-                withdrawn += vault.withdraw(maxShares, recipient);
             }
         }
     }


### PR DESCRIPTION
2 address checks in internal functions would always result in being `true` based on the current calls to these functions where the caller is always msg_sender() and not our contract address

Removing the checks has no change on the current functionality.